### PR TITLE
fix segfault when ; missing in word definition

### DIFF
--- a/s3.cpp
+++ b/s3.cpp
@@ -91,7 +91,7 @@ void n09() {
     if (stb[p] == 'e') { ++p; st.f[s] = (float)TOS; }
 }
 void fCreate() {
-    p=funcN(p); if (fa) { printf("-redef:%ld at %ld-", fn, fa); }
+    p=funcN(p);
     while (stb[p]==' ') { ++p; } funcs[fn]=p;
     while (stb[p++]!=';') {
         if (stb[p]=='\n') {
@@ -99,6 +99,7 @@ void fCreate() {
             fgets(&stb[p], 128, (FILE*)fp);
         }
     }
+    if (fa) { printf("-redef:%ld at %ld-", fn, fa); }
     if (h<p) { h=p; } st.i[0]=h;
 }
 void fRet() { p = st.i[r++]; if (rb < r) { r = rb; p = 0; } }

--- a/s3.cpp
+++ b/s3.cpp
@@ -93,7 +93,12 @@ void n09() {
 void fCreate() {
     p=funcN(p); if (fa) { printf("-redef:%ld at %ld-", fn, fa); }
     while (stb[p]==' ') { ++p; } funcs[fn]=p;
-    while (stb[p++]!=';') {}
+    while (stb[p++]!=';') {
+        if (stb[p]=='\n') {
+            if (fp == (long)stdin) { printf(": "); }
+            fgets(&stb[p], 128, (FILE*)fp);
+        }
+    }
     if (h<p) { h=p; } st.i[0]=h;
 }
 void fRet() { p = st.i[r++]; if (rb < r) { r = rb; p = 0; } }

--- a/tests
+++ b/tests
@@ -2,6 +2,10 @@ xX 0(reset s3)
 :CR 13,10,;
 :Code 0@1[nc@#58=(n1-c@59=(13,10,),];
 :YN #("y")~("n");
+:Multiline 1 2 3
++
++
+.;
 :Regs "(Regs:Todo)";
 :HelloWorld "hello world!";
 :Locs s3 s4 i3 d4 r3 r4 + "locals: %d";
@@ -17,6 +21,7 @@ Ver
 CR Regs
 CR HelloWorld
 CR 1 YN 0 YN
+CR Multiline
 CR 111 222 Locs
 CR 50 Mil Bench
 CR ULTestD


### PR DESCRIPTION
This change also supports multiline word definitions. See issues.